### PR TITLE
Fix crash when incorrect input file is given

### DIFF
--- a/Opossum.py
+++ b/Opossum.py
@@ -99,6 +99,7 @@ def main() :
 		samfile = pysam.AlignmentFile(args.BamFile, "rb")
 	except :
 		print 'Could not open file', args.BamFile
+		return
 
 	filename = os.path.split(args.BamFile)
 


### PR DESCRIPTION
If the input file name does not exist, Opossum will crash after it outputs the error message. This avoids the crash by closing the program after the error message is printed.